### PR TITLE
Towards transaction blocks.

### DIFF
--- a/FVIntmax.lean
+++ b/FVIntmax.lean
@@ -8,3 +8,4 @@ import «FVIntmax».Account
 import «FVIntmax».Block
 import «FVIntmax».RollupContract
 import «FVIntmax».TransactionBatch
+import «FVIntmax».Wheels

--- a/FVIntmax/Block.lean
+++ b/FVIntmax/Block.lean
@@ -2,6 +2,7 @@ import Mathlib.Data.Finmap
 
 namespace Intmax
 
+-- transfer (aggregator : K₁) (extradata : ByteArray) (commitment : C) (validUsers : K₂) (sigma : Sigma)
 /--
 2.4
 

--- a/FVIntmax/RollupContract.lean
+++ b/FVIntmax/RollupContract.lean
@@ -1,4 +1,11 @@
+import Mathlib.Data.Fintype.Basic
+
+import FVIntmax.Wheels.Oracle
+import FVIntmax.Wheels.Wheels
+
 import FVIntmax.Block
+import FVIntmax.TransactionBatch
+import FVIntmax.Wheels
 
 namespace Intmax
 
@@ -9,7 +16,7 @@ section RollupContract
 
 - Scontract := 𝔹*
 -/
-abbrev RollupState (K₁ K₂ V : Type) [OfNat V 0] [LE V] (C Sigma : Type) :=
+def RollupState (K₁ K₂ V : Type) [OfNat V 0] [LE V] (C Sigma : Type) :=
   List (Block K₁ K₂ C Sigma V)
 
 namespace RollupState
@@ -35,11 +42,41 @@ TODO(REVIEW): Does the order in which these get into the state matter? I'm choos
               It's not a big deal tho, we can do `s ++ [Block.deposit addr value]` and then shuffle.
 -/
 def deposit {K₁ K₂ C Sigma V : Type} [OfNat V 0] [LE V]
-            (addr : K₂) (value : {x : V // 0 ≤ x}) (s : RollupState K₁ K₂ V C Sigma) : RollupState K₁ K₂ V C Sigma :=
+            (addr : K₂) (value : { x : V // 0 ≤ x }) (s : RollupState K₁ K₂ V C Sigma) : RollupState K₁ K₂ V C Sigma :=
   Block.deposit addr value :: s
 
 end Depositing
 
+/-
+2.6
+-/
+section Transferring
+
+variable {K₁ : Type} [DecidableEq K₁] [Finite K₁]
+         {K₂ : Type} [Finite K₂]
+         {sender sender' : K₂} {senders : List K₂}
+         {V : Type} [DecidableEq V] [Finite V]
+
+/-
+Phase 1
+-/
+
+noncomputable def salt : UniquelyIndexed K₂ := default
+
+/--
+This is a corollary following from the way that `UniquelyIndexed` types are constructed.
+-/
+theorem salt_injective : Function.Injective (salt (K₂ := K₂)) := salt.injective
+
+noncomputable def salts : List K₂ → List (UniqueTokenT K₂) := List.map salt
+
+/--
+The only relevant property of salts.
+-/
+theorem injective_salts : Function.Injective (salts (K₂ := K₂)) :=
+  List.map_injective_iff.2 salt.injective
+
+end Transferring
 
 end RollupContract
 

--- a/FVIntmax/TransactionBatch.lean
+++ b/FVIntmax/TransactionBatch.lean
@@ -1,0 +1,220 @@
+import Mathlib.Data.Finite.Basic
+import Mathlib.Data.Finmap
+import Mathlib.Data.Fintype.Card
+import Mathlib.Data.Fintype.Powerset
+
+import FVIntmax.Wheels.Wheels
+
+import FVIntmax.Wheels
+
+import Mathlib
+
+namespace Intmax
+
+/-
+2.6 - Transaction batch
+-/
+section TransactionBatch
+
+/--
+PAPER: K := K1 ⨿ K2
+
+TODO(REVIEW): Can we assume that `addr₁ : K₁` and `addr₂ : K₂` are incomparable?
+              This is currently based on this assumption, as we have automatically
+              `[DecidableEq (K₁ ⊕ K₂)]` given `[DecidableEq K₁]` and `[DecidableEq K₂`],
+              but the instance compares e.g. `.inl 42 : Key Nat Nat`
+              and `.inr 42 : Key Nat Nat` _UNEQUAL_.
+
+              Of course this is fixable, essentially I'm just wondering if L₁ addresses can coincide with L₂ addresses. 
+-/
+abbrev Key (K₁ K₂ : Type) := K₁ ⊕ K₂
+
+section Finite
+
+variable {K₁ : Type} [Finite K₁]
+         {K₂ : Type} [Finite K₂]
+
+instance : Finite (Key K₁ K₂) := by
+  /-
+    We make a codomain `|K₁| + |K₂|` big. We put `K₁`s starting at 0 and we put `K₂`s starting at `|K₁|`.
+    To recover these, we map `K₁`s directly and subtract `|K₁|` for `K₂`s.
+    It is easy to show these are inverse to each other, thus yielding a bijection with a finite set of size `|K₁| + |K₂|`,
+    which is finite by definition.
+  -/
+  unfold Key
+  rw [finite_iff_exists_equiv_fin]
+  obtain ⟨w₁, hw₁⟩ := Finite.exists_equiv_fin K₁
+  obtain ⟨w₂, hw₂⟩ := Finite.exists_equiv_fin K₂
+  have h₁ := hw₁.some
+  have h₂ := hw₂.some
+  use w₁ + w₂
+  constructor
+  exact {
+    toFun := λ sum ↦
+               match sum with
+               | .inl k₁ => ⟨h₁ k₁, by omega⟩
+               | .inr k₂ => ⟨h₂ k₂ + w₁, by omega⟩
+    invFun := λ fin ↦
+                if h : fin < w₁
+                then .inl (h₁.invFun ⟨fin.1, h⟩)
+                else .inr (h₂.invFun ⟨fin.1 - w₁, by omega⟩)
+    left_inv := by unfold Function.LeftInverse
+                   intros sum
+                   rcases sum with k₁ | k₂ <;> simp
+    right_inv := by unfold Function.RightInverse Function.LeftInverse
+                    intros fin
+                    by_cases eq : fin < w₁ <;> aesop
+  }
+
+noncomputable instance : Fintype (Key K₁ K₂) :=
+  have := Fintype.ofFinite K₁
+  have := Fintype.ofFinite K₂
+  inferInstance
+
+/--
+PAPER: a transaction batch is an element of V₊ᵏ
+NB we do not impose `V₊`, here, but in `TransactionBatch.isValid` for convenience.
+As such, we will prove properties for _valid transaction batches_ rather than for any batches.
+NB as per usual, V does not need to be a latticed-ordered abelian group just yet.
+-/
+abbrev TransactionBatch (K₁ : Type) [Finite K₁] (K₂ : Type) [Finite K₂] (V : Type) :=
+  { m : Finmap (λ _ : Key K₁ K₂ ↦ V) // ∀ k, k ∈ m }
+
+/--
+A _valid transaction batch_ only contains nonnegative values of `V`.
+NB there is now a restriction on `V` such that the notion of nonnegative makes sense.
+-/
+abbrev TransactionBatch.isValid [DecidableEq K₁] [DecidableEq K₂] [LE V] [OfNat V 0]
+  (tb : TransactionBatch K₁ K₂ V) := ∀ x, 0 ≤ tb.1.lookup_h (a := x) (by cases tb; aesop)
+
+set_option linter.unusedVariables false in
+/--
+We define an equivalence between maps `K → V` and finmaps that are defined for all keys.
+This will be used to show that `TransactionBatch` is finite as long as the domain and codomain
+is finite.
+-/
+noncomputable def univFinmap (K : Type) [Fintype K] [DecidableEq K]
+                             (V : Type) [DecidableEq V] [Fintype V] :
+  { m : Finmap (λ _ : K ↦ V) // ∀ k, k ∈ m } ≃ (K → V) :=
+  {
+    toFun := λ m k ↦ m.1.lookup_h (a := k) (m.2 k)
+    invFun := λ f ↦
+      let fvals := { Sigma.mk x (f x) | x ∈ Finset.univ (α := K) }
+      have : Fintype ↑fvals := by
+        apply Fintype.subtype (s := { Sigma.mk x (f x) | x ∈ Finset.univ (α := K) })
+        aesop
+      ⟨⟨
+        Multiset.ofList fvals.toFinset.toList,
+        by /-
+             We start with no duplicates in the universal set for `K` and
+             the production of pairs `(k : K × f k : V)` keeps them intact.
+             As such, there are no duplicate keys in the final map.
+           -/
+           simp only [
+             Finset.mem_univ, true_and, Set.toFinset_setOf, Finset.univ_filter_exists,
+             Finset.coe_toList, Finset.image_val, fvals
+           ]
+           rw [←Multiset.nodup_keys]
+           have : (Finset.univ.val (α := K)).Nodup := Finset.nodup _
+           rwa [Multiset.keys_dedup_map_pres_univ this (by simp)]
+           ⟩,
+        by /-
+             We start with the universal set for `K`, which is complete by definiton.
+             Furthermore, we keep all `K`s and assign them values from the function's range.
+             This construction obviously preserves all keys.
+           -/
+           simp only [
+             Finset.mem_univ, true_and, Set.toFinset_setOf, Finset.univ_filter_exists,
+             Finset.coe_toList, Finset.image_val, true_implies, fvals
+           ]
+           intros k
+           rw [Finmap.mem_def]; dsimp
+           rw [Multiset.keys_dedup_map_pres_univ (Finset.nodup _) (by simp)]
+           simp only [Finset.mem_val, Finset.mem_univ]
+           ⟩
+    left_inv := by
+      /-
+        Two key observations:
+        - `⟨k, v⟩ ∈ m` iff `m.lookup k = v`
+        - in maps where all keys are present, the lookup on the universal set of all keys never fails
+      -/
+      simp [Function.LeftInverse]
+      rintro ⟨m, hm⟩ h
+      simp only [Finmap.lookup_h, Finmap.mk.injEq]
+      rw [
+        Multiset.dedup_eq_self.2 (Multiset.nodup_map_of_pres_keys_nodup (λ _ ↦ rfl) (Finset.nodup _)),
+        Multiset.ext
+      ]
+      intros kv
+      set m' := (Multiset.map (λ x ↦ _ : K → (_ : K) × V) _) with eqm'
+      have nodupm' : m'.Nodup := Multiset.nodup_map_of_pres_keys_nodup (by simp) (Finset.nodup _)
+      have nodupm : m.Nodup := by
+        rwa [← Multiset.nodup_keys, Multiset.keys, Multiset.nodup_map_iff_of_inj_on] at hm
+        rintro ⟨x₁, x₂⟩ hx ⟨y₁, y₂⟩ hy h'
+        set map' : Finmap (λ _ : K ↦ V) := { entries := m, nodupKeys := _ }
+        have eq₁ : ⟨x₁, x₂⟩ ∈ map'.entries := by aesop
+        have eq₂ : ⟨x₁, y₂⟩ ∈ map'.entries := by aesop
+        rw [←Finmap.lookup_eq_some_iff] at eq₁ eq₂
+        aesop -- cc is too slow here but it works...
+      rw [Multiset.count_eq_of_nodup nodupm', Multiset.count_eq_of_nodup nodupm]
+      set map' : Finmap (λ _ : K ↦ V) := { entries := m, nodupKeys := hm } with eqm
+      by_cases eq : kv ∈ m <;> (rcases kv with ⟨k, v⟩; simp [eq])
+      · by_contra contra
+        simp [eqm'] at contra
+        have : ⟨k, v⟩ ∈ map'.entries := by aesop
+        rw [←Finmap.lookup_eq_some_iff] at this
+        simp [Option.get] at contra; split at contra; cc
+      · simp [m']
+        intros contra
+        simp [Option.get] at contra; split at contra
+        next _ _ _ _ eq₃ _ =>
+          rw [Finmap.lookup_eq_some_iff] at eq₃; simp at eq₃
+          aesop -- cc is too slow here but it works...
+    right_inv := by
+      /-
+        Triviall follows from `⟨k, v⟩ ∈ m` iff `m.lookup k = v`.
+        The left inverse is more involved because we need do not get the functional property of
+        `f : K → V` for free and we have to recover it.
+      -/
+      simp [Function.RightInverse, Function.LeftInverse]
+      intros f; ext
+      simp [Finmap.lookup_h, Option.get]
+      split
+      next _ _ _ _ e _ => 
+        simp [Finmap.lookup_eq_some_iff] at e
+        exact e.symm
+  }
+
+/--
+For a finite K₁, K₂ and V, we can establish that a `TransactionBatch K₁ K₂ V` is finite.
+-/
+instance [Finite V] [DecidableEq K₁] [DecidableEq K₂] [DecidableEq V] :
+  Finite (TransactionBatch K₁ K₂ V) := by
+  /-
+    Follows trivially from the definition of `univFinmap`, for if we know that `(Key K₁ K₂ → V)`
+    is finite and we have a `... ≃ TransactionBatch K₁ K₂ V`, then the rhs is finite as well.
+  -/
+  have : Fintype K₁ := Fintype.ofFinite _
+  have : Fintype K₂ := Fintype.ofFinite _
+  have : Fintype V := Fintype.ofFinite _
+  exact @Finite.of_equiv _ _ _ (univFinmap (K := Key K₁ K₂) (V := V)).symm
+
+/-
+TODO(REVIEW):
+  Suppose we have the same theorem:
+  instance {K₁ : Type} [Finite K₁] [DecidableEq K₁]
+           {K₂ : Type} [Finite K₂] [DecidableEq K₂]
+           {V  : Type} [Finite V] [DecidableEq V] : Finite (TransactionBatch K₁ K₂ V)  
+
+  But instead we define `TransactionBatch K₁ K₂ V` to be a `Finmap ((_ : Key K₁ K₂) ↦ V)`.
+  Can we easily show that this is finite too? I think this would be more convenient,
+  but I couldn't easily prove this so I chose a slightly different approach.
+
+  Does the `univFinmap` maybe help?
+-/
+
+end Finite
+
+end TransactionBatch
+
+end Intmax

--- a/FVIntmax/Wheels.lean
+++ b/FVIntmax/Wheels.lean
@@ -1,0 +1,73 @@
+import Mathlib.Data.Finite.Defs
+import Mathlib.Data.Finmap
+import Mathlib.Data.Set.Image
+import Mathlib.Logic.Embedding.Basic
+
+namespace Intmax
+
+section UniquelyIndexed
+
+abbrev UniqueTokenT (α : Type) [Finite α] : Type := Fin (Finite.exists_equiv_fin α |>.choose)
+
+abbrev UniquelyIndexed (α : Type) [Finite α] : Type := α ↪ UniqueTokenT α
+
+namespace UniquelyIndexed
+
+noncomputable def attach (α : Type) [Finite α] : UniquelyIndexed α :=
+  have := Finite.exists_equiv_fin α
+  this.choose_spec.some.toEmbedding
+
+noncomputable instance {α : Type} [Finite α] : Inhabited (UniquelyIndexed α) := ⟨attach α⟩
+
+@[simp]
+lemma default_eq_attach (α : Type) [Finite α] : (default : UniquelyIndexed α) = attach α :=
+  rfl
+
+theorem injective {α : Type} [Finite α]
+  (f : UniquelyIndexed α) : Function.Injective f := f.2
+
+end UniquelyIndexed
+
+end UniquelyIndexed
+
+end Intmax
+
+theorem List.keys_zipWith_sigma {l₁ : List α} {l₂ : List β}
+  (h : l₁.length = l₂.length) : (List.zipWith Sigma.mk l₁ l₂).keys = l₁ := by
+  induction l₁ generalizing l₂ with
+  | nil => rfl
+  | cons hd tl ih => rcases l₂ <;> aesop
+
+namespace Multiset
+
+section Multiset
+
+variable {α : Type} {β : α → Type} {f : α → Sigma β} {m : Multiset α}
+
+theorem keys_map_eq (h : ∀ x, Sigma.fst (f x) = x) : (Multiset.map f m).keys = m := by
+  simp [Multiset.keys, h]
+
+theorem nodup_map_of_pres_keys_nodup
+  (h : ∀ x, Sigma.fst (f x) = x) (h₁ : m.Nodup) : (Multiset.map f m).Nodup := by
+  rw [Multiset.nodup_map_iff_inj_on h₁]
+  intros x _ y _ inj
+  have h₁ := h x
+  have h₂ := h y
+  cc
+
+theorem keys_dedup_map_pres_univ
+  (h : m.Nodup) [DecidableEq (Sigma β)] (h₁ : ∀ x, Sigma.fst (f x) = x) :
+  (Multiset.map f m).dedup.keys = m := by
+  have : (Multiset.map f m).Nodup := nodup_map_of_pres_keys_nodup h₁ h
+  rw [Multiset.dedup_eq_self.2 this, keys_map_eq h₁]
+
+theorem nodup_filter_of_nodup [DecidableEq α] [DecidablePred P]
+  (h : m.Nodup) : (Multiset.filter P m).Nodup := by
+  rw [Multiset.nodup_iff_count_eq_one] at h ⊢
+  intros x h₁
+  rw [Multiset.count_filter]
+  aesop
+
+end Multiset
+
+end Multiset

--- a/FVIntmax/Wheels/Oracle.lean
+++ b/FVIntmax/Wheels/Oracle.lean
@@ -1,7 +1,7 @@
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.Finmap
 
-namespace IntMax
+namespace Intmax
 
 /-
 _Random oracle_ is an idealised model that associates a new unique value with every input it has not yet encountered.
@@ -13,6 +13,7 @@ section RandomOracle
 /--
 Random oracle state.
 -/
+@[deprecated]
 structure RandomOracle (α : Type) (ω : Type) [Fintype ω] where
   m                 : Finmap (λ _ : α ↦ ω)
 
@@ -39,6 +40,7 @@ variable {α : Type}
 NB using `#1`, so we magically (using `choice`) obtain a `List` of all the elements from the codomain.
 This is convenient to simplify `hash`, hence this is chosen over `#0`.
 -/
+@[deprecated]
 noncomputable def RandomOracle.initial : RandomOracle α ω :=
   {
     m                 := ∅
@@ -53,7 +55,8 @@ Random oracle function.
 NB this is only computable because the process of creating the initial oracle state is not.
 We are using `#1`.
 -/
-def hash (st : RandomOracle α ω) (x : α) : Option (ω × RandomOracle α ω) :=
+@[deprecated]
+def RandomOracle.hash (st : RandomOracle α ω) (x : α) : Option (ω × RandomOracle α ω) :=
   match st.m.lookup x with
   | .some val => .some (val, st)
   | .none     => match st.availableCodomain with
@@ -62,4 +65,4 @@ def hash (st : RandomOracle α ω) (x : α) : Option (ω × RandomOracle α ω) 
 
 end RandomOracle
 
-end IntMax
+end Intmax

--- a/FVIntmax/Wheels/Wheels.lean
+++ b/FVIntmax/Wheels/Wheels.lean
@@ -63,4 +63,10 @@ scoped notation x "←ᵣ" f => isRandom f x
 
 end SimpleRandom
 
+section ByteArray
+
+deriving instance DecidableEq for ByteArray
+
+end ByteArray
+
 end Intmax


### PR DESCRIPTION
- add transaction batch
- add hashing mechanism, show that TransactionBatches are finite with the 'new' definition
- deprecate the oracle model

TODO(REVIEW): Any thoughts on the definition of transaction batch? I want to remove the \all k, k \in map condition.